### PR TITLE
Grant DNS Admin role to config-connector SA

### DIFF
--- a/200-gke-config-connector.tf
+++ b/200-gke-config-connector.tf
@@ -15,6 +15,7 @@ resource "google_service_account_iam_member" "config-connector_workload_identity
 # Set of permissions that the config-connector SA needs
 resource "google_project_iam_member" "config-connector" {
   for_each = toset([
+    "roles/dns.admin",
     "roles/iam.serviceAccountAdmin",
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",


### PR DESCRIPTION
DNS administration is required by config-connector since it is part of config-connector's responsibilities.