### PR TITLE
Grant project IAM Admin role to config-connector SA

### DIFF
--- a/200-gke-config-connector.tf
+++ b/200-gke-config-connector.tf
@@ -19,6 +19,7 @@ resource "google_project_iam_member" "config-connector" {
     "roles/iam.serviceAccountAdmin",
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
+    "roles/resourcemanager.projectIamAdmin",
   ])
 
   project = data.google_project.project.project_id


### PR DESCRIPTION
IAM administration is required by config-connector since it is part of config-connector's responsibilities.